### PR TITLE
[fix] Add index.php in nginx.conf + Remove useless dll extensions in …

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 massyas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 lychee_ynh
 ==========
+Package lychee for Yunohost
+
+Install & remove is OK.
+/!\ WARNING: remove will drop database and also remove uploaded pictures located in /home/yunohost.app/lychee  
+
+Upgrade not implemented. lychee version is a freeze of 2.1.1 that is kind of old but working OK.  
+ 
+Backup and restore in progress, not tested yet.  
 
 http://lychee.electerious.com/

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,7 +3,7 @@ location PATHTOCHANGE {
     if ($scheme = http) {
         rewrite ^ https://$server_name$request_uri? permanent;
     }
-    index index.html;
+    index index.html index.php;
     default_type text/html;
     try_files $uri $uri/ /index.html;
     
@@ -14,5 +14,6 @@ location PATHTOCHANGE {
         include fastcgi_params;
         fastcgi_param REMOTE_USER $remote_user;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
     }
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,19 +1,28 @@
-location PATHTOCHANGE {
-    alias ALIASTOCHANGE ;
-    if ($scheme = http) {
-        rewrite ^ https://$server_name$request_uri? permanent;
-    }
-    index index.html index.php;
+location YNH_EXAMPLE_PATH {
+	# Path to source
+	alias YNH_EXAMPLE_ALIAS ;
+	# Example PHP configuration
+	index index.html index.php;
     default_type text/html;
-    try_files $uri $uri/ /index.html;
-    
-    location ~ [^/]\.php(/|$) {
-        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-        fastcgi_pass unix:/var/run/php5-fpm-NAMETOCHANGE.sock;
-        fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param REMOTE_USER $remote_user;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
-        fastcgi_param SCRIPT_FILENAME $request_filename;
+	try_files $uri $uri/ index.php;
+	location ~ [^/]\.php(/|$) {
+		fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param REMOTE_USER $remote_user;
+		fastcgi_param PATH_INFO $fastcgi_path_info;
+		fastcgi_param SCRIPT_FILENAME $request_filename;
+	}
+	location ^~ YNH_EXAMPLE_PATH/data/medias/ {
+        	allow all;
+	}
+
+	location ^~ YNH_EXAMPLE_FOLDER/data/ { 
+        	deny all; 
+            	return 403;
     }
+    
+	# Include SSOWAT user panel.
+	include conf.d/yunohost_panel.conf.inc;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -14,7 +14,7 @@ location YNH_EXAMPLE_PATH {
 		fastcgi_param PATH_INFO $fastcgi_path_info;
 		fastcgi_param SCRIPT_FILENAME $request_filename;
 	}
-	location ^~ YNH_EXAMPLE_PATH/data/medias/ {
+	location ^~ YNH_EXAMPLE_PATH/uploads/ {
         	allow all;
 	}
 

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,6 +1,3 @@
-extension = php_mbstring.dll
-extension = php_exif.dll
-extension = php_gd2.dll
 max_execution_time = 200
 post_max_size = 200M
 upload_max_size = 200M

--- a/manifest.json
+++ b/manifest.json
@@ -1,37 +1,56 @@
 {
     "name": "Lychee",
     "id": "lychee",
+    "packaging_format": 1,
     "description": {
         "en": "Self-hosted photo-management done right",
         "fr": "Gestionnaire de photos autohebergé"
     },
+    "license": "The MIT License (MIT)",
+    "url": "https://lychee.electerious.com/",
     "developer": {
-        "name": "titoko",
-        "email": "titoko@titoko.fr",
-        "url": "http://dev.yunohost.org"
+        "name": "Tobias Reich",
+        "email": "tobias@electerious.com",
+        "url": "http://electerious.com"
+    },
+    "maintainer": {
+        "name": "massyas",
+        "email": "massyas@gmail.com"
+    },
+    "requirements": {
+        "yunohost": ">> 2.4.0"
     },
     "multi_instance": "true",
+    "services": [
+        "nginx"
+    ],
     "arguments": {
         "install" : [
         {
             "name": "domain",
+            "type": "domain",
             "ask": {
-                "en": "Choose a domain for Lychee"
+                "en": "Choose a domain for Lychee",
+                "fr": "Choisissez un nom de domaine pour lychee"
             },
             "example": "domain.org"
         },
         {
             "name": "path",
+            "type": "path",
             "ask": {
-                "en": "Choose a path for lychee"
+                "en": "Choose a path for lychee",
+                "fr": "Choisissez un chemin pour lychee"
             },
             "example": "/lychee",
             "default": "/lychee"
         },
         {
             "name": "admin_user",
+            "type": "user",            
             "ask": {
-                "en": "Choose login of  admin user"
+                "en": "Choose login of  admin user",
+                "fr": "Choisissez l’administrateur"
             },
             "example": "johndoe",
             "default": "admin"
@@ -39,7 +58,8 @@
         {
             "name": "admin_pwd",
             "ask": {
-                "en": "Choose password for admin user"
+                "en": "Choose password for admin user",
+                "fr": "Choisissez le mot de passe pour l’administrateur"
             }
         }
         ]

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
     "requirements": {
         "yunohost": ">> 2.4.0"
     },
-    "multi_instance": "true",
+    "multi_instance": true,
     "services": [
         "nginx"
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -46,20 +46,21 @@
             "default": "/lychee"
         },
         {
-            "name": "admin_user",
+            "name": "admin",
             "type": "user",            
             "ask": {
-                "en": "Choose login of  admin user",
-                "fr": "Choisissez l’administrateur"
+                "en": "Choose an admin user for lychee",
+                "fr": "Choisissez l’administrateur pour lychee"
             },
             "example": "johndoe",
             "default": "admin"
         },
         {
-            "name": "admin_pwd",
+            "name": "password",
+            "type": "password",
             "ask": {
-                "en": "Choose password for admin user",
-                "fr": "Choisissez le mot de passe pour l’administrateur"
+                "en": "Choose an admin password for lychee",
+                "fr": "Choisissez un mot de passe administrateur pour lychee"
             }
         }
         ]

--- a/scripts/backup
+++ b/scripts/backup
@@ -15,11 +15,11 @@ ynh_backup "/var/www/${app}" "sources"
 
 ### MySQL (remove if not used) ###
 # If a MySQL database is used:
-# # Dump the database
-# dbname=$app
-# dbuser=$app
-# dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
-# mysqldump -u "$dbuser" -p"$dbpass" --no-create-db "$dbname" > ./dump.sql
+# Dump the database
+dbname=$app
+dbuser=$app
+dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
+mysqldump -u "$dbuser" -p"$dbpass" --no-create-db "$dbname" > ./dump.sql
 ### MySQL end ###
 
 # Copy NGINX configuration
@@ -28,6 +28,6 @@ ynh_backup "/etc/nginx/conf.d/${domain}.d/${app}.conf" "nginx.conf"
 
 ### PHP (remove if not used) ###
 # If a dedicated php-fpm process is used:
-# # Copy PHP-FPM pool configuration
-# ynh_backup "/etc/php5/fpm/pool.d/${app}.conf" "php-fpm.conf"
+# Copy PHP-FPM pool configuration
+ynh_backup "/etc/php5/fpm/pool.d/${app}.conf" "php-fpm.conf"
 ### PHP end ###

--- a/scripts/backup
+++ b/scripts/backup
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Exit on command errors and treat unset variables as an error
+set -eu
+
+# See comments in install script
+app=$YNH_APP_INSTANCE_NAME
+
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
+
+# Backup sources & data
+# Note: the last argument is where to save this path, see the restore script.
+ynh_backup "/var/www/${app}" "sources"
+
+### MySQL (remove if not used) ###
+# If a MySQL database is used:
+# # Dump the database
+# dbname=$app
+# dbuser=$app
+# dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
+# mysqldump -u "$dbuser" -p"$dbpass" --no-create-db "$dbname" > ./dump.sql
+### MySQL end ###
+
+# Copy NGINX configuration
+domain=$(ynh_app_setting_get "$app" domain)
+ynh_backup "/etc/nginx/conf.d/${domain}.d/${app}.conf" "nginx.conf"
+
+### PHP (remove if not used) ###
+# If a dedicated php-fpm process is used:
+# # Copy PHP-FPM pool configuration
+# ynh_backup "/etc/php5/fpm/pool.d/${app}.conf" "php-fpm.conf"
+### PHP end ###

--- a/scripts/install
+++ b/scripts/install
@@ -1,9 +1,26 @@
 #!/bin/bash
 
+# Exit on command errors and treat unset variables as an error
+set -eu
+
+# This is a multi-instance app, meaning it can be installed several times independently
+# The id of the app as stated in the manifest is available as $YNH_APP_ID
+# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
+# The app instance name is available as $YNH_APP_INSTANCE_NAME
+#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
+#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
+#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
+# The app instance name is probably what you are interested the most, since this is
+# guaranteed to be unique. This is a good unique identifier to define installation path,
+# db names, ...
+app=$YNH_APP_INSTANCE_NAME
+
 # Retrieve arguments
-domain=$1
-path=$2
-user=$3
+domain=$YNH_APP_ARG_DOMAIN
+path_url=$YNH_APP_ARG_PATH
+user=$YNH_APP_ARG_ADMIN
+
+# Retrieve arguments
 user_pwd=$4
 user_pwd=$(echo -n $user_pwd | md5sum | cut -d ' ' -f 1)
 

--- a/scripts/install
+++ b/scripts/install
@@ -44,7 +44,7 @@ sudo mkdir -p $src_path
 
 #db
 db_pwd=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d '[A-Za-z0-9]' | sed -n 's/\(.\{24\}\).*/\1/p')
-db_user=lychee
+db_user=$app
 
 # Initialize database and store mysql password for upgrade
 sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../conf/db.sql) 
@@ -58,15 +58,15 @@ sudo mkdir -p $src_path
 sudo cp -r ../source/* $src_path
 
 # Create path for data
-data_path=/home/yunohost.app/lychee/
+data_path=/home/yunohost.app/$app/
 sudo mkdir -p $data_path
 sudo mv $src_path/uploads/* $data_path
 sudo rmdir $src_path/uploads/
 sudo ln -s $data_path $src_path/uploads
 
 # Copy config files
-sudo cp ../conf/php-fpm.conf /etc/php5/fpm/pool.d/lychee.conf
-sudo cp ../conf/php-fpm.ini /etc/php5/fpm/conf.d/20-lychee.ini
+sudo cp ../conf/php-fpm.conf /etc/php5/fpm/pool.d/$app.conf
+sudo cp ../conf/php-fpm.ini /etc/php5/fpm/conf.d/20-$app.ini
 sudo cp ../conf/config.php $src_path/data/
 
 # Set permissions
@@ -89,8 +89,8 @@ sudo sed -i "s@YNH_EXAMPLE_FOLDER@$folder_path@g" $nginx_conf
 sudo cp $nginx_conf /etc/nginx/conf.d/$domain.d/$app.conf
 
 # Configure db settings
-sudo sed -i "s@NAMETOCHANGE@lychee@g" /etc/php5/fpm/pool.d/lychee.conf
-sudo sed -i "s@NAMETOCHANGE@lychee@g" $src_path/data/config.php
+sudo sed -i "s@NAMETOCHANGE@$app@g" /etc/php5/fpm/pool.d/$app.conf
+sudo sed -i "s@NAMETOCHANGE@$app@g" $src_path/data/config.php
 sudo sed -i "s@PWDTOCHANGE@$db_pwd@g" $src_path/data/config.php
 sudo sed -i "s@login@$admin@g" ../conf/postini.sql
 sudo sed -i "s@pwd@$password@g" ../conf/postini.sql

--- a/scripts/install
+++ b/scripts/install
@@ -48,7 +48,7 @@ db_user=lychee
 
 # Initialize database and store mysql password for upgrade
 sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../conf/db.sql) 
-sudo yunohost app setting lychee mysqlpwd -v $db_pwd
+ynh_app_setting_set "$app" mysqlpwd -v $db_pwd
 
 # Create path for copying
 src_path=/var/www/$app

--- a/scripts/install
+++ b/scripts/install
@@ -20,6 +20,7 @@ domain=$YNH_APP_ARG_DOMAIN
 path=$YNH_APP_ARG_PATH
 admin=$YNH_APP_ARG_ADMIN
 password=$YNH_APP_ARG_PASSWORD
+password=$(echo -n $password | md5sum | cut -d ' ' -f 1)
 
 # Source YunoHost helpers
 source /usr/share/yunohost/helpers

--- a/scripts/install
+++ b/scripts/install
@@ -76,7 +76,7 @@ sudo chown -R www-data: $src_path/{data,plugins}
 sudo chown -R www-data: $data_path/
 sudo find $src_path -type f -exec chmod 644 {} +
 sudo find $src_path -type d -exec chmod 755 {} +
-sudo find $data_path -type d -exec chmod 755 {} +
+sudo find $data_path -type d -exec chmod 777 {} +
 
 # Configure nginx settings
 folder_path=${path%/}

--- a/scripts/install
+++ b/scripts/install
@@ -17,29 +17,31 @@ app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
-path_url=$YNH_APP_ARG_PATH
-user=$YNH_APP_ARG_ADMIN
+path=$YNH_APP_ARG_PATH
+admin=$YNH_APP_ARG_ADMIN
+password=$YNH_APP_ARG_PASSWORD
 
-# Retrieve arguments
-user_pwd=$4
-user_pwd=$(echo -n $user_pwd | md5sum | cut -d ' ' -f 1)
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
 
-# Check that user has an existing account
-sudo yunohost user list --json | grep -q "\"username\": \"$user\""
-if [[ ! $? -eq 0 ]]; then
-echo "Error : the chosen user does not exist"
-    exit 1
-fi
-
-# Store settings for further usage
-sudo yunohost app setting lychee user -v $user
-sudo yunohost app setting lychee user_pwd -v $user_pwd
+# Remove trailing slash
+[ "$path" != "/" ] && path=${path%/}
 
 # Check domain/path availability
-sudo yunohost app checkurl $domain$path -a lychee
-if [[ ! $? -eq 0 ]]; then
-    exit 1
-fi
+sudo yunohost app checkurl "${domain}${path}" -a "$app" \
+    || ynh_die "Path not available: ${domain}${path}"
+
+# Check the admin exists in YunoHost users
+ynh_user_exists $admin
+
+# Save app settings
+ynh_app_setting_set "$app" admin "$admin"
+
+# Create path for copying
+src_path=/var/www/$app
+sudo mkdir -p $src_path
+
+
 #db
 db_pwd=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d '[A-Za-z0-9]' | sed -n 's/\(.\{24\}\).*/\1/p')
 db_user=lychee
@@ -48,45 +50,54 @@ db_user=lychee
 sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../conf/db.sql) 
 sudo yunohost app setting lychee mysqlpwd -v $db_pwd
 
-# Remove trailing "/" for next commands
-path=${path%/}
+# Create path for copying
+src_path=/var/www/$app
+sudo mkdir -p $src_path
 
 # Copy files to the right place
-final_path=/var/www/lychee
-data_path=/home/yunohost.app/lychee/
+sudo cp -r ../source/* $src_path
 
-sudo mkdir -p $final_path
+# Create path for data
+data_path=/home/yunohost.app/lychee/
 sudo mkdir -p $data_path
-sudo cp -r ../source/* $final_path
+sudo mv $src_path/uploads/* $data_path
+sudo rmdir $src_path/uploads/
+sudo ln -s $data_path $src_path/uploads
+
+# Copy config files
 sudo cp ../conf/php-fpm.conf /etc/php5/fpm/pool.d/lychee.conf
 sudo cp ../conf/php-fpm.ini /etc/php5/fpm/conf.d/20-lychee.ini
-sudo cp ../conf/config.php $final_path/data/
-sudo mv $final_path/uploads/* $data_path
-sudo rmdir $final_path/uploads/
-sudo ln -s $data_path $final_path/uploads
+sudo cp ../conf/config.php $src_path/data/
 
-# Set permissions to lychee directory
-sudo chown -R www-data: $final_path
-sudo chown -R www-data: $data_path
+# Set permissions
+sudo chown -R root: $src_path
+sudo chown -R www-data: $src_path/{data,plugins}
+sudo chown -R www-data: $data_path/
+sudo find $src_path -type f -exec chmod 644 {} +
+sudo find $src_path -type d -exec chmod 755 {} +
+sudo find $data_path -type d -exec chmod 755 {} +
 
-# Modify Nginx configuration file and copy it to Nginx conf directory
-if [ -z "$path" ]; then
-    path="/"
-fi
+# Configure nginx settings
+folder_path=${path%/}
+sudo sed -i "s@YNH_EXAMPLE_PATH@$path@g" ../conf/nginx.conf
+# If path is only / (without subfolder), add trailing slash to alias
+alias_path=$src_path
+nginx_conf="../conf/nginx.conf"
+[ "$path" == '/' ] && alias_path=$alias_path'/'
+sudo sed -i "s@YNH_EXAMPLE_ALIAS@$alias_path@g" $nginx_conf
+sudo sed -i "s@YNH_EXAMPLE_FOLDER@$folder_path@g" $nginx_conf
+sudo cp $nginx_conf /etc/nginx/conf.d/$domain.d/$app.conf
+
+# Configure db settings
 sudo sed -i "s@NAMETOCHANGE@lychee@g" /etc/php5/fpm/pool.d/lychee.conf
-sudo sed -i "s@NAMETOCHANGE@lychee@g" $final_path/data/config.php
-sudo sed -i "s@PWDTOCHANGE@$db_pwd@g" $final_path/data/config.php
-sudo sed -i "s@PATHTOCHANGE@$path@g" ../conf/nginx.conf
-sudo sed -i "s@ALIASTOCHANGE@$final_path/@g" ../conf/nginx.conf
-sudo sed -i "s@NAMETOCHANGE@lychee@g" ../conf/nginx.conf
-sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/lychee.conf
-
-sudo sed -i "s@login@$user@g" ../conf/postini.sql
-sudo sed -i "s@pwd@$user_pwd@g" ../conf/postini.sql
+sudo sed -i "s@NAMETOCHANGE@lychee@g" $src_path/data/config.php
+sudo sed -i "s@PWDTOCHANGE@$db_pwd@g" $src_path/data/config.php
+sudo sed -i "s@login@$admin@g" ../conf/postini.sql
+sudo sed -i "s@pwd@$password@g" ../conf/postini.sql
 sudo mysql -u$db_user -p$db_pwd -D $db_user < ../conf/postini.sql
 
 # Reload Nginx and regenerate SSOwat conf
 sudo service php5-fpm restart
 sudo service nginx reload
-sudo yunohost app setting lychee skipped_uris -v "/"
+ynh_app_setting_set "$app" skipped_uris -v "/"
 sudo yunohost app ssowatconf

--- a/scripts/install
+++ b/scripts/install
@@ -48,7 +48,7 @@ db_user=$app
 
 # Initialize database and store mysql password for upgrade
 sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../conf/db.sql) 
-ynh_app_setting_set "$app" mysqlpwd -v $db_pwd
+ynh_app_setting_set "$app" mysqlpwd $db_pwd
 
 # Create path for copying
 src_path=/var/www/$app
@@ -99,5 +99,5 @@ sudo mysql -u$db_user -p$db_pwd -D $db_user < ../conf/postini.sql
 # Reload Nginx and regenerate SSOwat conf
 sudo service php5-fpm restart
 sudo service nginx reload
-ynh_app_setting_set "$app" skipped_uris -v "/"
+ynh_app_setting_set "$app" skipped_uris "/"
 sudo yunohost app ssowatconf

--- a/scripts/install
+++ b/scripts/install
@@ -77,6 +77,7 @@ sudo chown -R www-data: $data_path/
 sudo find $src_path -type f -exec chmod 644 {} +
 sudo find $src_path -type d -exec chmod 755 {} +
 sudo find $data_path -type d -exec chmod 777 {} +
+sudo chmod 777 $src_path/data
 
 # Configure nginx settings
 folder_path=${path%/}

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-db_user=lychee
-db_name=lychee
+# Exit and treat unset variables as an error
+set -u
+
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
+
+app=$YNH_APP_INSTANCE_NAME
+domain=$(ynh_app_setting_get $app domain)
+
+db_user=$app
+db_name=$app
 root_pwd=$(sudo cat /etc/yunohost/mysql)
-domain=$(sudo yunohost app setting lychee domain)
 
 mysql -u root -p$root_pwd -e "DROP DATABASE $db_name ; DROP USER $db_user@localhost ;"
-sudo rm -rf /var/www/lychee
-sudo rm -f /etc/nginx/conf.d/$domain.d/lychee.conf
-sudo rm -f /etc/php5/fpm/pool.d/lychee.conf
-sudo rm -f /etc/php5/fpm/conf.d/20-lychee.ini
-sudo rm -rf /home/yunohost.app/lychee
+sudo rm -rf /var/www/$app
+
+# Remove nginx conf and reload nginx service
+sudo rm -f /etc/nginx/conf.d/$domain.d/$app.conf
+sudo rm -f /etc/php5/fpm/pool.d/$app.conf
+sudo rm -f /etc/php5/fpm/conf.d/20-$app.ini
+sudo rm -rf /home/yunohost.app/$app
 
 sudo service php5-fpm restart
 sudo service nginx reload

--- a/scripts/restore
+++ b/scripts/restore
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Note: each files and directories you've saved using the ynh_backup helper
+# will be located in the current directory, regarding the last argument.
+
+# Exit on command errors and treat unset variables as an error
+set -eu
+
+# See comments in install script
+app=$YNH_APP_INSTANCE_NAME
+
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
+
+# Retrieve old app settings
+domain=$(ynh_app_setting_get "$app" domain)
+path_url=$(ynh_app_setting_get "$app" path_url)
+
+# Check domain/path availability
+sudo yunohost app checkurl "${domain}${path_url}" -a "$app" \
+    || ynh_die "Path not available: ${domain}${path_url}"
+
+# Restore sources & data
+src_path="/var/www/${app}"
+sudo cp -a ./sources "$src_path"
+
+# Restore permissions to app files
+# you may need to make some file and/or directory writeable by www-data (nginx user)
+sudo chown -R root: "$src_path"
+
+### MySQL (remove if not used) ###
+# If a MySQL database is used:
+# # Create and restore the database
+# dbname=$app
+# dbuser=$app
+# dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
+# ynh_mysql_create_db "$dbname" "$dbuser" "$dbpass"
+# ynh_mysql_connect_as "$dbuser" "$dbpass" "$dbname" < ./dump.sql
+### MySQL end ###
+
+# Restore NGINX configuration
+sudo cp -a ./nginx.conf "/etc/nginx/conf.d/${domain}.d/${app}.conf"
+
+### PHP (remove if not used) ###
+# If a dedicated php-fpm process is used:
+# # Copy PHP-FPM pool configuration and reload the service
+# sudo cp -a ./php-fpm.conf "/etc/php5/fpm/pool.d/${app}.conf"
+# sudo service php5-fpm reload
+### PHP end ###
+
+# Restart webserver
+sudo service nginx reload

--- a/scripts/restore
+++ b/scripts/restore
@@ -30,12 +30,12 @@ sudo chown -R root: "$src_path"
 
 ### MySQL (remove if not used) ###
 # If a MySQL database is used:
-# # Create and restore the database
-# dbname=$app
-# dbuser=$app
-# dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
-# ynh_mysql_create_db "$dbname" "$dbuser" "$dbpass"
-# ynh_mysql_connect_as "$dbuser" "$dbpass" "$dbname" < ./dump.sql
+# Create and restore the database
+dbname=$app
+dbuser=$app
+dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
+ynh_mysql_create_db "$dbname" "$dbuser" "$dbpass"
+ynh_mysql_connect_as "$dbuser" "$dbpass" "$dbname" < ./dump.sql
 ### MySQL end ###
 
 # Restore NGINX configuration
@@ -44,8 +44,8 @@ sudo cp -a ./nginx.conf "/etc/nginx/conf.d/${domain}.d/${app}.conf"
 ### PHP (remove if not used) ###
 # If a dedicated php-fpm process is used:
 # # Copy PHP-FPM pool configuration and reload the service
-# sudo cp -a ./php-fpm.conf "/etc/php5/fpm/pool.d/${app}.conf"
-# sudo service php5-fpm reload
+sudo cp -a ./php-fpm.conf "/etc/php5/fpm/pool.d/${app}.conf"
+sudo service php5-fpm reload
 ### PHP end ###
 
 # Restart webserver

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,35 +1,35 @@
 #!/bin/bash
 
+# Exit on command errors and treat unset variables as an error
+set -eu
+
+# This is a multi-instance app, meaning it can be installed several times independently
+# The id of the app as stated in the manifest is available as $YNH_APP_ID
+# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
+# The app instance name is available as $YNH_APP_INSTANCE_NAME
+#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
+#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
+#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
+# The app instance name is probably what you are interested the most, since this is
+# guaranteed to be unique. This is a good unique identifier to define installation path,
+# db names, ...
+app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve arguments
-domain=$(sudo yunohost app setting lychee domain)
-path=$(sudo yunohost app setting lychee path)
-db_pwd=$(sudo yunohost app setting lychee mysqlpwd)
+domain=$YNH_APP_ARG_DOMAIN
+path=$YNH_APP_ARG_PATH
+admin=$YNH_APP_ARG_ADMIN
+password=$YNH_APP_ARG_PASSWORD
 
-# Remove trailing "/" for next commands
-path=${path%/}
+# Source YunoHost helpers
+source /usr/share/yunohost/helpers
 
-# Copy files to the right place
-data_path=/home/yunohost.app/lychee/
-final_path=/var/www/lychee
-sudo mkdir -p $data_path
-sudo mkdir -p $final_path
-sudo rm -R $final_path/uploads
-sudo cp -r ../source/* $final_path
-sudo cp ../conf/php-fpm.conf /etc/php5/fpm/pool.d/lychee.conf
-sudo cp ../conf/php-fpm.ini /etc/php5/fpm/conf.d/20-lychee.ini
-sudo cp ../conf/config.php $final_path/data/
-sudo rm -R $final_path/uploads
-sudo ln -s $data_path $final_path/uploads
+# Remove trailing slash
+[ "$path" != "/" ] && path=${path%/}
 
-# Set permissions to lychee directory
-sudo chown -R www-data: $final_path
-sudo chown -R www-data: $data_path
+# Create path for copying
+src_path=/var/www/$app
+sudo mkdir -p $src_path
 
-# Modify Nginx configuration file and copy it to Nginx conf directory
-if [ -z "$path" ]; then
-    path="/"
-fi
-sudo sed -i "s@NAMETOCHANGE@lychee@g" /etc/php5/fpm/pool.d/lychee.conf
-sudo sed -i "s@NAMETOCHANGE@lychee@g" $final_path/data/config.php
-sudo sed -i "s@PWDTOCHANGE@$db_pwd@g" $final_path/data/config.php
+# To be implemented
+ynh_die "Upgrade operation not implemented yet"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -29,7 +29,7 @@ source /usr/share/yunohost/helpers
 
 # Create path for copying
 src_path=/var/www/$app
-sudo mkdir -p $src_path
+#sudo mkdir -p $src_path
 
 # To be implemented
 ynh_die "Upgrade operation not implemented yet"


### PR DESCRIPTION
[fix] Add index.php in nginx.conf + Remove useless dll extensions in php-fpm.ini
Hello,
I've changed php-fpm.ini to fix issue "errors showing up in user's mailbox #3 " since these dll extensions are useless on debian system.
I've added index.php index empty page was shown after installation.
